### PR TITLE
Fix RevertCommand bugs

### DIFF
--- a/src/main/java/command/RevertCommand.java
+++ b/src/main/java/command/RevertCommand.java
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 import studentlist.StudentList;
 import ui.Messages;
 import ui.UI;
+import university.UniversityRepository;
 
 /**
  * Command to revert the allocation status of all students in the StudentList.
@@ -44,8 +45,9 @@ public class RevertCommand extends Command {
         // Ensure studentList is initialized
         assert studentList != null : "StudentList cannot be null during revert operation";
 
-        // Perform the revert action
+        // Perform the revert action on student list and uni repo
         studentList.revertAllocation();
+        UniversityRepository.resetMap();
 
         // Log completion and notify the user
         logger.log(Level.INFO, "Revert operation completed.");

--- a/src/main/java/command/RevertCommand.java
+++ b/src/main/java/command/RevertCommand.java
@@ -40,7 +40,7 @@ public class RevertCommand extends Command {
      */
     @Override
     public void run() {
-        logger.log(Level.INFO, "Starting revert operation.");
+        logger.log(Level.FINE, "Starting revert operation.");
 
         // Ensure studentList is initialized
         assert studentList != null : "StudentList cannot be null during revert operation";
@@ -50,7 +50,7 @@ public class RevertCommand extends Command {
         UniversityRepository.resetMap();
 
         // Log completion and notify the user
-        logger.log(Level.INFO, "Revert operation completed.");
+        logger.log(Level.FINE, "Revert operation completed.");
         ui.printResponse(Messages.REVERT_COMPLETE);
     }
 }

--- a/src/main/java/university/UniversityRepository.java
+++ b/src/main/java/university/UniversityRepository.java
@@ -8,13 +8,18 @@ import java.util.HashMap;
  * It provides a static method to retrieve a university by its index.
  */
 public class UniversityRepository {
-
     // HashMap storing universities with an Integer index as the key and University as the value
-    private static final HashMap<Integer, University> universityMap = new HashMap<>();
+    private static HashMap<Integer, University> universityMap = new HashMap<>();
 
     // Static block to initialize the repository with predefined universities
-
     static {
+        initialiseMap();
+    }
+
+    /**
+     * Initialises the map of universities in this UniRepo class.
+     */
+    private static void initialiseMap() {
         universityMap.put(1, new University("The Uni of Western Australia", "UWA",1 ));
         universityMap.put(2, new University("The University of Melbourne", "UM",1));
         universityMap.put(3, new University("The Australian National Uni", "TANU",1));
@@ -115,9 +120,13 @@ public class UniversityRepository {
      * @param index The index of the university to retrieve.
      * @return The University object corresponding to the given index, or null if no such university exists.
      */
-    
     public static University getUniversityByIndex(int index) {
         return universityMap.get(index);
+    }
+
+    public static void resetMap() {
+        universityMap = new HashMap<>();
+        initialiseMap();
     }
 }
 


### PR DESCRIPTION
1. Fix `RevertCommand` bug where `University` are not resetting their spots when revert command is run.
2. Fix logging level to `FINE` to prevent debug printing for target users.
Close #110 and #111 