### PR TITLE
Fix Multiple Allocation Bug

### DIFF
--- a/src/main/java/allocator/Allocator.java
+++ b/src/main/java/allocator/Allocator.java
@@ -93,6 +93,9 @@ public class Allocator {
     public StudentList allocate() {
         studentList.sortStudentsByDescendingGPA(studentList.getList());
         for (Student student : studentList.getList()) {
+            if (student.getSuccessfullyAllocated()) {
+                continue;
+            }
             for (int uni : student.getUniPreferences()) {
                 University university = UniversityRepository.getUniversityByIndex(uni);
                 if (university.getSpotsLeft() > 0 && student.getGpa() >= minimumGPA) {


### PR DESCRIPTION
Fix #117 

Add a condition in ``Allocator`` to skip those students that are already successfully allocated.
Now multiple allocation behaves as normal.

![image](https://github.com/user-attachments/assets/fcbc4dc5-f58b-483f-a727-f18054357abd)
