### PR TITLE
PE-D bugfix

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -243,11 +243,11 @@ nicely formatted ASCII table.
 
 #### Stats Command
 
-The `StatCommand` class implements the `stats` command, which provides GPA-related statistics (average GPA or minimum GPA) for students who have chosen a specified university. The command syntax is `stats <stat_type> <UNI_INDEX>`, where `<stat_type>` can be `-avggpa` for average GPA or `-mingpa` for minimum GPA.
+The `StatCommand` class implements the `stats` command, which provides GPA-related statistics (average GPA or minimum GPA) for students who have been allocated to a specified university. The command syntax is `stats <stat_type> <UNI_INDEX>`, where `<stat_type>` can be `-avggpa` for average GPA or `-mingpa` for minimum GPA.
 
 ![StatSequence](UML_Diagrams/StatSequence.drawio.svg)
 
-The above sequence diagram illustrates the execution of the `stats` command, specifically the `stats -avg` example, which calculates the average GPA for students who have chosen the specified university.
+The above sequence diagram illustrates the execution of the `stats` command, specifically the `stats -avg` example, which calculates the average GPA for students who have been allocated to the specified university.
 
 * The `StatCommand` class initiates the command with the syntax `stats -avg <UNI_INDEX>`, where `-avg` indicates that the average GPA calculation is required, and `<UNI_INDEX>` specifies the target university by its index.
 * `StatCommand` calls the `getUniversityByIndex()` method on `UniversityRepo`, passing the university index as an argument.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -160,7 +160,7 @@ Here is the list of possible commands:
                                or 'filter <list> <gpa/id> <ascending/descending>'
                 Example: filter list gpa ascending
 
-    stats       Displays GPA statistics for students who have chosen a specific partner university.
+    stats       Displays GPA statistics for students who have been allocated a specified uni.
                 Usage:
                 stats -avggpa <UNI_INDEX>  Displays the average GPA for the specified university.
                 stats -mingpa <UNI_INDEX>  Displays the minimum GPA for the specified university.
@@ -280,7 +280,7 @@ Here is the list:
 
 ### View allocation statistics: ``stats``
 
-Displays the average or minimum GPA for the students who have chosen the specified partner university.  
+Displays the average or minimum GPA for the students who have been allocated to the specified partner university.  
 Format: `stats -avggpa UNI_INDEX` or `stats -mingpa UNI_INDEX`   
 Example output:  
 

--- a/src/main/java/allocator/Allocator.java
+++ b/src/main/java/allocator/Allocator.java
@@ -96,6 +96,7 @@ public class Allocator {
             throw SEPEmptyException.rejectAllocateEmpty();
         }
 
+        boolean isChanged = false;
         studentList.sortStudentsByDescendingGPA(studentList.getList());
         for (Student student : studentList.getList()) {
             if (student.getSuccessfullyAllocated()) {
@@ -104,12 +105,16 @@ public class Allocator {
             for (int uni : student.getUniPreferences()) {
                 University university = UniversityRepository.getUniversityByIndex(uni);
                 if (university.getSpotsLeft() > 0 && student.getGpa() >= minimumGPA) {
+                    isChanged = true;
                     university.removeASpot();
                     student.setAllocatedUniversity(uni);
                     student.setSuccessfullyAllocated(true);
                     break;
                 }
             }
+        }
+        if (!isChanged) {
+            throw SEPEmptyException.rejectAllocateNoChange();
         }
         studentList.sortStudentsByAscendingId(studentList.getList());
         return studentList;

--- a/src/main/java/exceptions/SEPEmptyException.java
+++ b/src/main/java/exceptions/SEPEmptyException.java
@@ -42,4 +42,9 @@ public class SEPEmptyException extends SEPException {
     public static SEPEmptyException rejectAllocateEmpty() {
         return new SEPEmptyException("Unable to allocate with empty student list, try adding students! :>");
     }
+
+    public static SEPEmptyException rejectAllocateNoChange() {
+        return new SEPEmptyException("No changes made in the allocation. \n" +
+                "If you've edited the original student list, try run `revert` first then `allocate`! :>");
+    }
 }

--- a/src/main/java/university/University.java
+++ b/src/main/java/university/University.java
@@ -53,6 +53,15 @@ public class University {
     }
 
     /**
+     * Increments the number of available spots by one, typically called when
+     * a student is deleted from this university.
+     */
+    public void addASpot(){
+        assert spotsLeft >= 0 : "spot left cannot be negative";
+        this.spotsLeft++;
+    }
+
+    /**
      * Returns a string representation of the university in the format:
      * "Full Name (Acronym)".
      * 

--- a/src/test/java/allocator/AllocatorTest.java
+++ b/src/test/java/allocator/AllocatorTest.java
@@ -1,6 +1,5 @@
-package findoursep;
+package allocator;
 
-import allocator.Allocator;
 import exceptions.SEPDuplicateException;
 import exceptions.SEPEmptyException;
 import exceptions.SEPException;
@@ -68,12 +67,7 @@ public class AllocatorTest {
     @Test
     public void testAllocateWithCriteria() throws SEPException {
         allocator.setMinimumGPA("minimum 4.0");
-        StudentList allocatedStudents = allocator.allocate();
-
-        assertEquals(-1, allocatedStudents.getList().get(0).getAllocatedUniversity());
-        assertEquals(-1, allocatedStudents.getList().get(1).getAllocatedUniversity());
-        assertEquals(-1, allocatedStudents.getList().get(2).getAllocatedUniversity());
-        assertEquals(-1, allocatedStudents.getList().get(3).getAllocatedUniversity());
+        assertThrows(SEPEmptyException.class, () -> allocator.allocate());
     }
 
     @Test

--- a/src/test/java/parser/ParserTest.java
+++ b/src/test/java/parser/ParserTest.java
@@ -89,9 +89,9 @@ public class ParserTest {
     @Test
     public void testStatAvgCommand() {
         // Simulate user input for 'stats -avggpa' command
-        parser.parseInput("add id/A1234567I gpa/5.0 p/{36,61,43}");
-        parser.parseInput("add id/A1234567J gpa/3.0 p/{36,61,43}");
-        parser.parseInput("add id/A1234567K gpa/1.0 p/{36,61,43}");
+        parser.parseInput("add id/A1234567I gpa/4.0 p/{36,61,43}");
+        parser.parseInput("add id/A1234567J gpa/3.5 p/{36,61,43}");
+        parser.parseInput("add id/A1234567K gpa/4.0 p/{36,61,43}");
         parser.parseInput("allocate");
         String input = "stats -avggpa 36";
 

--- a/src/test/java/parser/ParserTest.java
+++ b/src/test/java/parser/ParserTest.java
@@ -92,6 +92,7 @@ public class ParserTest {
         parser.parseInput("add id/A1234567I gpa/5.0 p/{36,61,43}");
         parser.parseInput("add id/A1234567J gpa/3.0 p/{36,61,43}");
         parser.parseInput("add id/A1234567K gpa/1.0 p/{36,61,43}");
+        parser.parseInput("allocate");
         String input = "stats -avggpa 36";
 
         // Set up the output stream to capture console output
@@ -108,7 +109,7 @@ public class ParserTest {
         // Verify the expected output
         String expectedOutput = HORIZONTAL_LINE 
                             + "\n" 
-                            + "The average GPA for university index 36 (The University of Hong Kong) is: 3.00" 
+                            + "The average GPA for university index 36 (The University of Hong Kong) is: 4.00" 
                             + "\n" 
                             + HORIZONTAL_LINE;
         assertEquals(expectedOutput,outContent.toString().trim());
@@ -120,10 +121,11 @@ public class ParserTest {
     @Test
     public void testStatMinCommand() {
         // Simulate user input for 'stats -avggpa' command
-        parser.parseInput("add id/A1234567I gpa/5.0 p/{36,61,43}");
-        parser.parseInput("add id/A1234567J gpa/3.0 p/{36,61,43}");
-        parser.parseInput("add id/A1234567K gpa/1.0 p/{36,61,43}");
-        String input = "stats -mingpa 36";
+        parser.parseInput("add id/A1234567I gpa/5.0 p/{37,61,43}");
+        parser.parseInput("add id/A1234567J gpa/3.0 p/{37,61,43}");
+        parser.parseInput("add id/A1234567K gpa/1.0 p/{37,61,43}");
+        parser.parseInput("allocate");
+        String input = "stats -mingpa 37";
 
         // Set up the output stream to capture console output
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
@@ -139,7 +141,7 @@ public class ParserTest {
         // Verify the expected output
         String expectedOutput = HORIZONTAL_LINE 
                             + "\n" 
-                            + "The minimum GPA for university index 36 (The University of Hong Kong) is: 1.00" 
+                            + "The minimum GPA for university index 37 (The Chinese Uni of Hong Kong) is: 5.00" 
                             + "\n" 
                             + HORIZONTAL_LINE;
         assertEquals(expectedOutput,outContent.toString().trim());
@@ -183,7 +185,7 @@ public class ParserTest {
     @Test
     public void revertCommand_populatedStudentList_success() {
         // Simulate user input for allocating a list of students
-        parser.parseInput("add id/A1234567I gpa/5.0 p/{36,61,43}");
+        parser.parseInput("add id/A1234567I gpa/5.0 p/{38,61,43}");
         parser.parseInput("add id/A2468101J gpa/4.9 p/{32,50,8}");
         parser.parseInput("add id/A3691215K gpa/4.8 p/{29,61,17}");
         parser.parseInput("allocate");


### PR DESCRIPTION
fix #176 #160 #152 #148 

main changes include:
* add a reminder message to run `revert` if `allocate` changes nothing
* modify `stats`  command behavior, to display gpa statistics of students that have been **allocated to** the specified uni
* fix `delete` command bug, it does not release the quota when deleteing a student who has been allocated

sample:
1. reminder message
![image](https://github.com/user-attachments/assets/57748f38-26cf-426b-b406-46de49924c35)


2.  new `stats` behavior
![image](https://github.com/user-attachments/assets/ac64976b-e665-42a1-bad7-021dac4d6a04)

3. `deleteCommand` bug fix
![image](https://github.com/user-attachments/assets/0dc41c1b-8f69-4323-a6cf-c19db3fa4c84)
